### PR TITLE
Change pack location in default emacs-live.el

### DIFF
--- a/.emacs-live.el
+++ b/.emacs-live.el
@@ -1,1 +1,12 @@
-(live-add-packs '(flowa-pack))
+;;; emacs-live.el --- configuration file for emacs-live
+;;; Commentary:
+
+;;; Currently loads flowa-pack outside of emacs-live, in order
+;;; to make updating emacs-live more easy.
+;;; Indeed, power of the horse!
+
+;;; Code:
+
+(live-add-packs '(~/.flowa-pack))
+
+;;; emacs-live.el ends here

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ This is a *pack* for the wonderful [emacs-live](https://github.com/overtone/emac
 ### Copy the pack files
 
 * copy .emacs-live.el to your home dir
-* copy rest of the contents to ~/.emacs.d/packs/flowa-pack/
+* copy rest of the contents to ~/.flowa-pack/
+
+* OPTIONAL: just git clone the stuff to ~/.flowa-pack
+Naturally it's okay to just put the stufz to wherever you like, and change the respective folder
+in instructions. You know the stuff.
 
 ### Setup git modules
 
@@ -20,5 +24,5 @@ Go to the clone directory and run:
 ### Setup helm
 
 Unfortunately helm requires a manual step. You'll have to run the make yourself.
-* Go to ~/.emacs.d/packs/flowa-pack/lib/helm
+* Go to ~/.flowa-pack/lib/helm
 * Run: ```make```


### PR DESCRIPTION
Decouples from emacs-live base directory, in order to make updating the
core live more easy.